### PR TITLE
Make GitHub detect *.ff and *.boot as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.ff linguist-language=Forth
+*.boot linguist-language=Forth
+hanoi linguist-language=Forth
+hello linguist-language=Forth
+see linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.ff` and `.boot` files as Forth.  Also the three shebang Forth files.

Thanks!